### PR TITLE
Hamburger mobile nav

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -31,6 +31,27 @@ export function ResumeIcon() {
   );
 }
 
+// Three horizontal lines — used as the mobile nav trigger.
+export function MenuIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" aria-hidden>
+      <line x1="4" y1="7"  x2="20" y2="7" />
+      <line x1="4" y1="12" x2="20" y2="12" />
+      <line x1="4" y1="17" x2="20" y2="17" />
+    </svg>
+  );
+}
+
+// X — used to dismiss the mobile nav drawer.
+export function CloseIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" aria-hidden>
+      <line x1="6"  y1="6"  x2="18" y2="18" />
+      <line x1="18" y1="6"  x2="6"  y2="18" />
+    </svg>
+  );
+}
+
 // Standard GitHub mark — solid single-path silhouette. Used as the repo
 // link on project detail pages.
 export function GithubIcon() {

--- a/src/layout/Nav.tsx
+++ b/src/layout/Nav.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useState } from 'react';
 import type { Tab, Theme } from '../types';
-import { SunIcon, MoonIcon } from '../components/Icons';
+import { SunIcon, MoonIcon, MenuIcon, CloseIcon } from '../components/Icons';
 
 interface NavProps {
   tab: Tab;
@@ -17,16 +18,45 @@ const TABS: { id: Tab; label: string }[] = [
 ];
 
 export default function Nav({ tab, setTab, theme, toggleTheme }: NavProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // Lock the .site scroll container while the drawer is open so swiping
+  // the drawer doesn't carry the page underneath. .site (not body) is the
+  // actual scroll container, so we have to mutate it directly.
+  useEffect(() => {
+    const site = document.querySelector('.site') as HTMLElement | null;
+    if (!site) return;
+    site.style.overflow = menuOpen ? 'hidden' : '';
+    return () => { site.style.overflow = ''; };
+  }, [menuOpen]);
+
+  // ESC closes the drawer.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [menuOpen]);
+
+  const goTo = (id: Tab) => {
+    setTab(id);
+    setMenuOpen(false);
+  };
+
   return (
     <nav className="nav">
       <div className="nav-container">
-        <button className="brand" onClick={() => setTab('home')}>
+        <button className="brand" onClick={() => goTo('home')}>
           {/* Andy (one of Snoopy's siblings) — small mark to the left of
               the wordmark. Also used as the site's favicon. */}
           <img className="brand-mark" src="/images/andy.png" alt="" />
           <span className="brand-text">Andrew Li</span>
         </button>
-        <ul className="nav-links">
+
+        {/* Desktop / wide-screen nav — hidden under ≤768px via CSS. */}
+        <ul className="nav-links nav-desktop">
           {TABS.map((t) => (
             <li key={t.id}>
               <button
@@ -48,6 +78,64 @@ export default function Nav({ tab, setTab, theme, toggleTheme }: NavProps) {
             </button>
           </li>
         </ul>
+
+        {/* Mobile hamburger — hidden above 768px via CSS. */}
+        <button
+          className="nav-mobile-toggle"
+          onClick={() => setMenuOpen(true)}
+          aria-label="Open menu"
+          aria-expanded={menuOpen}
+          aria-controls="mobile-nav-drawer"
+        >
+          <MenuIcon />
+        </button>
+      </div>
+
+      {/* Mobile drawer — full-viewport overlay with a slide-in panel on
+          the right. Inert when closed (pointer-events: none, aria-hidden). */}
+      <div
+        id="mobile-nav-drawer"
+        className={`nav-drawer${menuOpen ? ' open' : ''}`}
+        aria-hidden={!menuOpen}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Site navigation"
+      >
+        <div
+          className="nav-drawer-backdrop"
+          onClick={() => setMenuOpen(false)}
+        />
+        <div className="nav-drawer-panel">
+          <div className="nav-drawer-head">
+            <button
+              className="theme-toggle"
+              onClick={toggleTheme}
+              aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
+            </button>
+            <button
+              className="nav-mobile-close"
+              onClick={() => setMenuOpen(false)}
+              aria-label="Close menu"
+            >
+              <CloseIcon />
+            </button>
+          </div>
+          <ul className="nav-drawer-list">
+            {TABS.map((t) => (
+              <li key={t.id}>
+                <button
+                  className={`nav-drawer-link${tab === t.id ? ' active' : ''}`}
+                  onClick={() => goTo(t.id)}
+                >
+                  <span>{t.label}</span>
+                  <span className="nav-drawer-arrow">→</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </nav>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -1016,11 +1016,154 @@ section > .image-grid {
 }
 .site::-webkit-scrollbar-thumb:hover { background: var(--text-tertiary); }
 
+/* === Mobile hamburger nav ===
+   Hidden by default; the @media block at the bottom flips the visibility
+   so the inline nav-links disappear and the hamburger + drawer take over. */
+.nav-mobile-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: none;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.nav-mobile-toggle:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.nav-mobile-toggle svg { width: 22px; height: 22px; display: block; }
+
+/* Drawer overlay — fixed full-viewport. Inert when closed via visibility +
+   pointer-events; the panel slides in on .open. The visibility transition
+   is delayed by the panel's slide duration so the overlay stays mounted
+   during the close animation. */
+.nav-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  pointer-events: none;
+  visibility: hidden;
+  transition: visibility 0s linear 0.3s;
+}
+.nav-drawer.open {
+  pointer-events: auto;
+  visibility: visible;
+  transition: visibility 0s linear 0s;
+}
+
+.nav-drawer-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.site.light .nav-drawer-backdrop {
+  background: rgba(40, 32, 18, 0.45);
+}
+.nav-drawer.open .nav-drawer-backdrop { opacity: 1; }
+
+.nav-drawer-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 86%;
+  max-width: 360px;
+  background: var(--bg);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-3) var(--space-5) var(--space-7);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  box-shadow: -20px 0 60px rgba(0, 0, 0, 0.35);
+  overflow-y: auto;
+}
+.nav-drawer.open .nav-drawer-panel { transform: translateX(0); }
+
+.nav-drawer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) 0 var(--space-4);
+  margin-bottom: var(--space-3);
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-mobile-close {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.nav-mobile-close:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.nav-mobile-close svg { width: 18px; height: 18px; display: block; }
+
+.nav-drawer-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.nav-drawer-link {
+  width: 100%;
+  background: none;
+  border: 0;
+  padding: var(--space-4) 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  font-family: var(--serif);
+  font-size: 26px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  text-align: left;
+  transition: color 0.15s, padding-left 0.15s;
+}
+.nav-drawer-link:hover,
+.nav-drawer-link:active { color: var(--accent); padding-left: var(--space-2); }
+.nav-drawer-link.active { color: var(--accent); font-weight: 500; }
+
+.nav-drawer-arrow {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--text-tertiary);
+  transition: color 0.15s, transform 0.15s;
+}
+.nav-drawer-link:hover .nav-drawer-arrow,
+.nav-drawer-link.active .nav-drawer-arrow {
+  color: var(--accent);
+  transform: translateX(4px);
+}
+
 /* === Responsive ===
-   Three breakpoints:
+   Two main breakpoints:
    - 900px : tablet / narrow desktop — collapse 2-column rows to stacked
-   - 640px : phones — stack everything, shrink nav, fluid hero type
-   - 400px : compact phones — drop brand wordmark, tighten nav further
+   - 768px : mobile — swap inline nav for hamburger drawer, fluid hero,
+             single-column grids, stacked contact rows
    The site stays usable down to ~320px (iPhone SE). */
 @media (max-width: 900px) {
   .nav-container { padding: var(--space-3) var(--space-4); }
@@ -1037,34 +1180,27 @@ section > .image-grid {
   .image-grid.cols-3 { grid-template-columns: 1fr 1fr; }
 }
 
-@media (max-width: 640px) {
-  /* Nav — keep one row, shrink everything, tighten gaps */
-  .nav-container { padding: var(--space-2) var(--space-3); }
-  .brand { font-size: 15px; gap: var(--space-1); }
-  .brand-mark { width: 36px; height: 36px; }
-  .nav-links { gap: 0; }
-  .nav-link {
-    padding: var(--space-2) var(--space-2);
-    font-size: 12px;
-    letter-spacing: 0;
-  }
-  .theme-toggle {
-    width: 30px;
-    height: 30px;
-    margin-left: var(--space-1);
-  }
+@media (max-width: 768px) {
+  /* Swap nav presentation: inline links out, hamburger in. */
+  .nav-desktop { display: none !important; }
+  .nav-mobile-toggle { display: inline-flex; }
+
+  /* Tighter nav header on phones */
+  .nav-container { padding: var(--space-2) var(--space-4); }
+  .brand { font-size: 16px; gap: var(--space-2); }
+  .brand-mark { width: 38px; height: 38px; }
 
   /* Sections — pull padding in, smaller titles */
   .section { padding: var(--space-7) var(--space-4); }
-  .section-title { font-size: 28px; }
+  .section-title { font-size: 30px; }
   .section-eyebrow { font-size: 10.5px; margin-bottom: var(--space-3); }
 
   /* Hero — let the name shrink further than the default clamp floor */
   .hero {
     padding: var(--space-7) var(--space-4);
-    min-height: calc(100vh - 56px);
+    min-height: calc(100vh - 60px);
   }
-  .hero-name { font-size: clamp(40px, 13vw, 60px); }
+  .hero-name { font-size: clamp(40px, 13vw, 64px); }
   .hero-tagline {
     font-size: clamp(17px, 4.5vw, 22px);
     margin-bottom: var(--space-6);
@@ -1119,14 +1255,9 @@ section > .image-grid {
 }
 
 @media (max-width: 400px) {
-  /* Drop the "Andrew Li" wordmark — Andy mark alone identifies the brand,
-     and nav-links + theme toggle reclaim the horizontal space. */
-  .brand-text { display: none; }
-  .nav-link {
-    padding: 6px var(--space-1);
-    font-size: 11.5px;
-  }
   .section-title { font-size: 26px; }
+  .brand-text { font-size: 14px; }
+  .brand-mark { width: 34px; height: 34px; }
 }
 
 /* === Project-detail typography utilities ===


### PR DESCRIPTION
## Summary
- Hamburger trigger replaces inline nav-links under 768px
- Right-side slide-in drawer with large serif nav items, theme toggle, and an X close
- Drawer closes on tap-outside, X, ESC, or selecting an item; scroll lock on the `.site` container while open
- Switched the mobile breakpoint from 640px → 768px to match the hamburger trigger

## Test plan
- [x] `npm run build` succeeds
- [ ] iPhone Safari: open drawer, tap each nav item, theme toggle, swipe-to-dismiss feel
- [ ] iPad portrait (768px): hamburger present, drawer fits
- [ ] Desktop ≥769px: inline nav restored, drawer never visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)