### PR TITLE
Open resume in browser PDF viewer

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -17,8 +17,8 @@ export function MoonIcon() {
   );
 }
 
-// Document with a folded corner + text lines. Used as the resume download
-// affordance on the About page.
+// Document with a folded corner + text lines. Used as the "open resume"
+// affordance on the About page (opens the PDF in a new tab).
 export function ResumeIcon() {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -50,13 +50,14 @@ export default function About({ onNav }: AboutProps) {
             </p>
 
             <p>
-              Feel free to check out the rest of this site, or download my resume for a quick summary of my work:
+              Feel free to check out the rest of this site, or open my resume for a quick summary of my work:
               <a
                 className="resume-icon-link"
                 href="/downloadables/andrew_li_resume.pdf"
-                download
-                title="Download resume (PDF)"
-                aria-label="Download resume (PDF)"
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Open resume (PDF)"
+                aria-label="Open resume (PDF) in a new tab"
               >
                 <ResumeIcon />
               </a>


### PR DESCRIPTION
## Summary
- Remove the `download` attribute on the About-page resume link so the browser uses its built-in PDF viewer
- Add `target="_blank"` + `rel="noopener noreferrer"` so the resume opens in a new tab and the portfolio stays in the original tab
- Update copy ("download" → "open") and aria-label to match the new behavior

## Test plan
- [x] `npm run build` succeeds
- [ ] Click resume icon — should render the PDF in a new tab, not trigger a save dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)