### PR TITLE
Faster first paint

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,20 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&family=Lato:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700&family=Source+Serif+4:opsz,wght@8..60,300;8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet" />
+    <!-- Images are served from Cloudinary — start the TLS handshake
+         alongside the fonts so the first card image lands faster. -->
+    <link rel="preconnect" href="https://res.cloudinary.com" crossorigin />
+    <!-- Font request trimmed to weights/styles actually referenced in
+         styles.css:
+           JetBrains Mono: 400 (default), 500 (.badge)
+           Lato:           400 (body), 700 (.about-bio strong + 600
+                           emphasis substitutions), 400-italic
+                           (.resume-entry-role)
+           Source Serif 4: 300 (.hero-tagline), 400 (.hero-name),
+                           500 (most headings), 600 (.brand)
+         Browser substitution covers font-weight: 500/600 declarations
+         on Lato (no native 500; 500→400 and 600→700 substitution). -->
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Lato:ital,wght@0,400;0,700;1,400&family=Source+Serif+4:opsz,wght@8..60,300;8..60,400;8..60,500;8..60,600&display=swap" rel="stylesheet" />
 
     <!-- Schema.org person markup so search engines understand who the
          site belongs to. -->

--- a/src/projects/ProjectDetail.tsx
+++ b/src/projects/ProjectDetail.tsx
@@ -1,10 +1,16 @@
+import { lazy, Suspense, type ComponentType } from 'react';
 import type { ProjectCard } from '../types';
 import { useDocMeta } from '../hooks/useDocMeta';
-import JohnStockbotDetail from './details/JohnStockbotDetail';
-import StairBotDetail from './details/StairBotDetail';
-import PrinterUpgradesDetail from './details/PrinterUpgradesDetail';
-import BedframeHolderDetail from './details/BedframeHolderDetail';
-import VexGuiDetail from './details/VexGuiDetail';
+
+// Per-project detail bodies are large enough (image grids, embeds,
+// long prose) to be worth splitting out of the main bundle — the user
+// only sees them after clicking a card, and the parent header / back
+// link / title render immediately while the body chunk streams in.
+const JohnStockbotDetail    = lazy(() => import('./details/JohnStockbotDetail'));
+const StairBotDetail        = lazy(() => import('./details/StairBotDetail'));
+const PrinterUpgradesDetail = lazy(() => import('./details/PrinterUpgradesDetail'));
+const BedframeHolderDetail  = lazy(() => import('./details/BedframeHolderDetail'));
+const VexGuiDetail          = lazy(() => import('./details/VexGuiDetail'));
 
 /**
  * Full-page project detail view that takes over the Projects tab when
@@ -18,8 +24,11 @@ interface Props {
   onBack: () => void;
 }
 
-// Map of project id → detail body component. Add new project writeups here.
-const DETAILS: Record<string, () => JSX.Element> = {
+// Map of project id → detail body component. Add new project writeups
+// here. The type accepts both eager components and lazy(() => import())
+// results so individual detail bodies can be split out of the main
+// bundle.
+const DETAILS: Record<string, ComponentType> = {
   'john-stockbot':     JohnStockbotDetail,
   'stair-bot':         StairBotDetail,
   'printer-upgrades':  PrinterUpgradesDetail,
@@ -55,7 +64,12 @@ export default function ProjectDetail({ project, onBack }: Props) {
 
         <hr className="divider" />
 
-        {Body && <Body />}
+        {/* Suspense fallback is null — the header above is already
+            visible so the page is never blank; the body fades in once
+            its chunk arrives (sub-100ms on a warm connection). */}
+        <Suspense fallback={null}>
+          {Body && <Body />}
+        </Suspense>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Three lightweight optimizations, no visual or content changes:

- **Trim Google Fonts URL** — drop weights/styles unreferenced in `styles.css` (Lato 300/900 + italic 300/700, JetBrains Mono 300/600, Source Serif 4 700). Browser substitution still handles existing `font-weight: 500/600` on Lato (already the rendered behavior).
- **Preconnect to `res.cloudinary.com`** — TLS handshake starts during HTML parse so the first card image lands sooner.
- **`React.lazy` for the 5 project detail bodies** — header renders eagerly (page is never blank), body streams under `<Suspense fallback={null}>`. Main bundle 209.26 → 185.82 kB (**-5.97 kB gzip**); detail chunks load only when a card is clicked.

## Test plan
- [x] `npm run build` succeeds; detail chunks split cleanly
- [ ] Tabs render identically
- [ ] Project cards open with no visible blank flash on a normal connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)